### PR TITLE
Adding support for absolute path for source[].src

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,9 +52,15 @@ var loadHTML = function(files,client,basePath){
 		if(pushError(conditions[i],errorMsg[i])) return;
 	}
 	
-    for(var i=0;i<s.length;i++){
-      files.unshift(htmlPattern(path.join(basePath,s[i].src)));
-    }
+	for(var i=0;i<s.length;i++){
+		var src = s[i].src;
+		
+		if (!src.startsWith('/')) {
+			src = path.join(basePath, src);
+		}
+		
+		files.unshift(htmlPattern(src));
+	}
     
 	files.unshift(jsPattern(path.join(__dirname, '/lib/appender.js')));
 	files.unshift(jsPattern(path.join(__dirname, '/lib/oftype.js')));


### PR DESCRIPTION
Hello,

i'm encountering an issue in my tests due to karma-html,

i have the following warning :

```
06 12 2022 16:47:24.169:WARN [filelist]: Pattern "/my_absolute_source_path/my_absolute_dist_path/index.html" does not match any file.
```

it's due to a path.join inside index.js, which does not allow absolute path.

this PR wrap the path.join in a `!src.startsWith('/')` check to prevent this.

thanks.